### PR TITLE
add yarn meteor command to package.json and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/ssr-server/ssr.git && cd ssr
 meteor yarn install
 cd demo
 meteor yarn install
-meteor --settings ./settings.json
+yarn meteor
 ```
 
 ### Client side call

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,7 +2,8 @@
   "name": "ssr-demo",
   "private": true,
   "scripts": {
-    "start": "meteor run"
+    "start": "meteor run",
+    "meteor": "meteor --settings settings.json"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
reduces the painful typo **"meteor --settings settings.json"** everytime starting the app.