### PR TITLE
Add i18next's xhr backend to demo

### DIFF
--- a/demo/imports/i18n/i18nClient.js
+++ b/demo/imports/i18n/i18nClient.js
@@ -4,16 +4,16 @@ import XHR from 'i18next-xhr-backend';
 i18n
   .use(XHR)
   .init({
-      whitelist: ['en', 'tr', 'fr'],
-      fallbackLng: 'en',
-      debug: false,
-      // have a common namespace used around the full app
-      ns: ['common', 'greetings'],
-      defaultNS: 'common',
+    whitelist: ['en', 'tr', 'fr'],
+    fallbackLng: 'en',
+    debug: false,
+    // have a common namespace used around the full app
+    ns: ['common', 'greetings'],
+    defaultNS: 'common',
 
-      backend: {
-          loadPath: `${Meteor.absoluteUrl()}locales/{{lng}}/{{ns}}.json`,
-      },
+    backend: {
+      loadPath: `${Meteor.absoluteUrl()}locales/{{lng}}/{{ns}}.json`,
+    },
   });
 
 export default i18n;

--- a/demo/imports/i18n/i18nClient.js
+++ b/demo/imports/i18n/i18nClient.js
@@ -1,13 +1,19 @@
 import i18n from 'i18next';
+import XHR from 'i18next-xhr-backend';
 
 i18n
+  .use(XHR)
   .init({
-    whitelist: ['en', 'tr', 'fr'],
-    fallbackLng: 'en',
-    debug: false,
-    // have a common namespace used around the full app
-    ns: ['common', 'greetings'],
-    defaultNS: 'common',
+      whitelist: ['en', 'tr', 'fr'],
+      fallbackLng: 'en',
+      debug: false,
+      // have a common namespace used around the full app
+      ns: ['common', 'greetings'],
+      defaultNS: 'common',
+
+      backend: {
+          loadPath: `${Meteor.absoluteUrl()}locales/{{lng}}/{{ns}}.json`,
+      },
   });
 
 export default i18n;


### PR DESCRIPTION
This adds the i18next XHR backend to the demo. It was already included in the `package.json` but not used.