### PR TITLE
Add style to helmet renders in step 7

### DIFF
--- a/src/server/steps/applicationRendering.jsx
+++ b/src/server/steps/applicationRendering.jsx
@@ -54,7 +54,7 @@ const applicationRendering = (stepResults) => {
     // Create body
     stepResults.req.dynamicBody = `<div id="react">${bodyMarkup}</div>${stepResults.contextMarkup}`;
     // Create head
-    stepResults.req.dynamicHead = ['title', 'meta', 'link', 'script']
+    stepResults.req.dynamicHead = ['title', 'meta', 'link', 'script', 'style']
       .reduce((acc, key) => `${acc}${helmetHead[key].toString()}`, '');
 
     // Add html attributes


### PR DESCRIPTION
Hi!

So enhancement request here. Current working:

Helmet styles are excluded from render.

This makes Material-UI SSR throw warnings, because the prerendered styles are included in the server render, but not in client, so checksum is invalid for react.

Adding `'style'` to the `dynamicHead` pick list allows for injecting CSS that needs not to be in the react root.